### PR TITLE
リファクタリングセットDX

### DIFF
--- a/mikutter_fcmnotify.rb
+++ b/mikutter_fcmnotify.rb
@@ -4,31 +4,31 @@
 
 Plugin.create(:mikutter_fcmnotify) do
 
- on_favorite do |service, user, msg|
-  # ポータル状態でif !user.me?にすると自分のふぁぼも通知される
+  on_favorite do |service, user, msg|
+    # ポータル状態でif !user.me?にすると自分のふぁぼも通知される
     if msg.from_me?
       data = {
-       :title => "Favorited by #{user.idname}",
-       :body => msg.description,
-       :url => msg.uri
-     }
-     # 意味不明な名前だけどこれでfcmをcallしてる
-     nishino(data)
+        :title => "Favorited by #{user.idname}",
+        :body => msg.description,
+        :url => msg.uri
+      }
+      # 意味不明な名前だけどこれでfcmをcallしてる
+      nishino(data)
     end
- end 
+  end 
 
   on_mention do |service ,msg|
     msg.each do |m|
       if Time.now - m.created < 10 and !m.retweet?
         data = {
-        :title => "Mentioned by #{m.user.idname}",
-        :body => m.description,
-        :url => m.uri
-         }
-         nishino(data)
-     end
-   end
- end
+          :title => "Mentioned by #{m.user.idname}",
+          :body => m.description,
+          :url => m.uri
+        }
+        nishino(data)
+      end
+    end
+  end
 
   on_retweet do |msg|
     msg.each do |m|
@@ -36,12 +36,12 @@ Plugin.create(:mikutter_fcmnotify) do
         m.retweet_source_d.next { |s|
           if s.from_me?
             data = {
-            :title => "ReTweeted by #{m.user.idname}",
-            :body => s.description,
-            :url => s.uri
-           }
-           nishino(data)
-         end
+              :title => "ReTweeted by #{m.user.idname}",
+              :body => s.description,
+              :url => s.uri
+            }
+            nishino(data)
+          end
         }
       end
     end
@@ -54,18 +54,18 @@ Plugin.create(:mikutter_fcmnotify) do
   def nishino(data)
     if UserConfig[:how_many] = "0"
       howmany = 29
-     else
+    else
       howmany = UserConfig[:how_many]
-     end
-     if UserConfig[:nishinokana]
+    end
+    if UserConfig[:nishinokana]
       i = 0
-     else
+    else
       i = howmany - 1
-     end
-     while i < howmany do
+    end
+    while i < howmany do
       Plugin.call(:fcm, data)
       i = i + 1
-     end
+    end
   end
 
   settings "mikutter_fcmnotify" do

--- a/mikutter_fcmnotify.rb
+++ b/mikutter_fcmnotify.rb
@@ -7,25 +7,25 @@ Plugin.create(:mikutter_fcmnotify) do
   on_favorite do |service, user, msg|
     # ポータル状態でif !user.me?にすると自分のふぁぼも通知される
     if msg.from_me?
-      data = {
+      kana = {
         title: "Favorited by #{user.idname}",
         body: msg.description,
         url: msg.uri
       }
       # 意味不明な名前だけどこれでfcmをcallしてる
-      nishino(data)
+      nishino kana
     end
   end
 
   on_mention do |service ,msg|
     msg.each do |m|
       if Time.now - m.created < 10 and !m.retweet?
-        data = {
+        kana = {
           title: "Mentioned by #{m.user.idname}",
           body: m.description,
           url: m.uri
         }
-        nishino(data)
+        nishino kana
       end
     end
   end
@@ -35,12 +35,12 @@ Plugin.create(:mikutter_fcmnotify) do
       if Time.now - m.created < 10
         m.retweet_source_d.next { |s|
           if s.from_me?
-            data = {
+            kana = {
               title: "ReTweeted by #{m.user.idname}",
               body: s.description,
               url: s.uri
             }
-            nishino(data)
+            nishino kana
           end
         }
       end

--- a/mikutter_fcmnotify.rb
+++ b/mikutter_fcmnotify.rb
@@ -8,9 +8,9 @@ Plugin.create(:mikutter_fcmnotify) do
     # ポータル状態でif !user.me?にすると自分のふぁぼも通知される
     if msg.from_me?
       data = {
-        :title => "Favorited by #{user.idname}",
-        :body => msg.description,
-        :url => msg.uri
+        title: "Favorited by #{user.idname}",
+        body: msg.description,
+        url: msg.uri
       }
       # 意味不明な名前だけどこれでfcmをcallしてる
       nishino(data)
@@ -21,9 +21,9 @@ Plugin.create(:mikutter_fcmnotify) do
     msg.each do |m|
       if Time.now - m.created < 10 and !m.retweet?
         data = {
-          :title => "Mentioned by #{m.user.idname}",
-          :body => m.description,
-          :url => m.uri
+          title: "Mentioned by #{m.user.idname}",
+          body: m.description,
+          url: m.uri
         }
         nishino(data)
       end
@@ -36,9 +36,9 @@ Plugin.create(:mikutter_fcmnotify) do
         m.retweet_source_d.next { |s|
           if s.from_me?
             data = {
-              :title => "ReTweeted by #{m.user.idname}",
-              :body => s.description,
-              :url => s.uri
+              title: "ReTweeted by #{m.user.idname}",
+              body: s.description,
+              url: s.uri
             }
             nishino(data)
           end

--- a/mikutter_fcmnotify.rb
+++ b/mikutter_fcmnotify.rb
@@ -15,7 +15,7 @@ Plugin.create(:mikutter_fcmnotify) do
       # 意味不明な名前だけどこれでfcmをcallしてる
       nishino(data)
     end
-  end 
+  end
 
   on_mention do |service ,msg|
     msg.each do |m|


### PR DESCRIPTION
先程一緒に酒を飲んだときにレビューをしてほしいとお願いされたので気づいたところを数点修正しました。修正項目は少ないですが変更行数は多くなってしまっているので、コミットごとに見てください。

# 063f523 * fix indent

Rubyを採用しているプロジェクトのコーディングスタンダードの多くは、インデントには2スペースを採用しているため、スペース2つに統一しました。エディタ・IDEのオートインデント機能も初期設定は2スペースになっているので、それを利用するとインデントを気にしなくて良くなって快適になると思います。

# 7e891aa * delete trailing spaces

スペースで終わっている行があったので、そのスペースを削除しました。

# bdcf491 * use modern hash syntax

Symbolをキーに持つHashは、 `{:key => value}` ではなく `{key: value}`と書くことができます。

# c675ffb * But still I can't tell my words of too late

一般的に、 `data` のような抽象的な単語を変数名に使うのは言語に関係なくアンチパターンとされています。理由としては、そのデータがどういったものかを表す変数名をつけたほうが良いというものがよく言われていることです。

説明的であるべきなのはメソッド名も同じです。特にRubyでは、メソッド名がその処理内容を説明するものであるべきであると強く考えられています[要出典]。

たとえば `nishino(data)` というのは何をしているかよくわかりませんね。

それは別にどうでも良いのですが、Ruby 2.0からは `funcname argment` という形式のメソッド呼び出しが削除され、 `funcname(argument)` のみとなりました。

この話をRubyに詳しいマンにすると、今でも使えるぞと言ってくると思います。彼らは時間跳躍の能力を持たないため、私がRuby 2.0でこのシンタックスが廃止されなかった世界線を手繰り寄せたことを認知できず、無邪気にも最初から廃止されなかったと錯覚しているに過ぎないため、そういった†持たぬもの†意見は聞き入れるに値しません。私がこのような†干渉†を行ったのは、このpull-reqをvalidにするためです。

先の話と合わせて、 `nishino kana` といったコードのほうが、意味はわかりませんがこのコードが何をしたいのかをより具体的に説明できていると思います。